### PR TITLE
Fix misunderstood pom and readme instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ As documented in: https://cwiki.apache.org/confluence/display/JMETER/JMeterMaven
 
 ## Starting the GUI
 To start the JMeter GUI:
-<br>First you would need to run: `mvn clean verify`
+<br>First you may need to run: `mvn clean verify`
 <br>Then: `mvn jmeter:configure jmeter:gui`
 <br>Note: Its been recommended to not run official load tests in the GUI itself.

--- a/pom.xml
+++ b/pom.xml
@@ -5,37 +5,35 @@
   <artifactId>jmeter-maven-starter</artifactId>
   <version>1.0</version>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.lazerycode.jmeter</groupId>
-                    <artifactId>jmeter-maven-plugin</artifactId>
-                    <version>3.7.0</version>
-                    <executions>
-                        <!-- Generate JMeter configuration -->
-                        <execution>
-                            <id>configuration</id>
-                            <goals>
-                                <goal>configure</goal>
-                            </goals>
-                        </execution>
-                        <!-- Run JMeter tests -->
-                        <execution>
-                            <id>jmeter-tests</id>
-                            <goals>
-                                <goal>jmeter</goal>
-                            </goals>
-                        </execution>
-                        <!-- Fail build on errors in test -->
-                        <execution>
-                            <id>jmeter-check-results</id>
-                            <goals>
-                                <goal>results</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.lazerycode.jmeter</groupId>
+                <artifactId>jmeter-maven-plugin</artifactId>
+                <version>3.7.0</version>
+                <executions>
+                    <!-- Generate JMeter configuration -->
+                    <execution>
+                        <id>configuration</id>
+                        <goals>
+                            <goal>configure</goal>
+                        </goals>
+                    </execution>
+                    <!-- Run JMeter tests -->
+                    <execution>
+                        <id>jmeter-tests</id>
+                        <goals>
+                            <goal>jmeter</goal>
+                        </goals>
+                    </execution>
+                    <!-- Fail build on errors in test -->
+                    <execution>
+                        <id>jmeter-check-results</id>
+                        <goals>
+                            <goal>results</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
pom.xml did not need plugin management tag, actually it won't work later on to run tests with it. We may not need to run mvn clean verify it seems